### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/hughes123b/ee81b083-a84e-402c-86fe-66122e658262/87f195d8-188d-4b37-a907-7d064b690566/_apis/work/boardbadge/4f5bffdd-ea81-45ff-86f6-aa6c9c4623bc)](https://dev.azure.com/hughes123b/ee81b083-a84e-402c-86fe-66122e658262/_boards/board/t/87f195d8-188d-4b37-a907-7d064b690566/Microsoft.RequirementCategory)
 # apache-jmeter-template
 The template repository for the Apache-JMeter course on Learning Lab.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/hughes123b/ee81b083-a84e-402c-86fe-66122e658262/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.